### PR TITLE
CSS Tab Moved

### DIFF
--- a/components/QuickCssIcon.jsx
+++ b/components/QuickCssIcon.jsx
@@ -35,10 +35,7 @@ const Tooltip = getModuleByDisplayName('Tooltip', false);
 module.exports = React.memo((compProps) => {
   const settingsModule = getModule([ 'open', 'saveAccountChanges' ], false);
   const handleOnClick = async () => {
-    settingsModule.open('pc-moduleManager-themes');
-
-    const quickCSSTab = await waitFor('.powercord-entities-manage-tabs [data-item-id="QUICK_CSS"]');
-    quickCSSTab.click();
+    settingsModule.open('pc-moduleManager-css');
   };
 
   if (compProps.inSetting) {

--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -114,10 +114,7 @@ module.exports = class Settings extends React.Component {
     const { selectedItem } = this.state;
     const settingsModule = getModule([ 'open', 'saveAccountChanges' ], false);
     const handleOnClick = async () => {
-      settingsModule.open('pc-moduleManager-themes');
-  
-      const quickCSSTab = await waitFor('.powercord-entities-manage-tabs [data-item-id="QUICK_CSS"]');
-      quickCSSTab.click();
+      settingsModule.open('pc-moduleManager-css');
     };
 
     return <Flex align={Flex.Align.CENTER} className={breadcrumbClasses.breadcrumbs}>


### PR DESCRIPTION
The CSS tab has been moved out of Themes, so this fixes the button that opens it.